### PR TITLE
Add context files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # vc-examples Changelog
 
+## 3.0.0 - 2023-TBD
+
+### Added
+- Add context files for `movieTicket`, `alumni` and `safechef` credentials.
+
+### Changed
+- **BREAKING**: Update context URLs for `movieTicket`, `alumni` and `safechef`
+  credentials.
+
 ## 2.1.0 - 2023-03-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ npm test
 Please add or update credentials in the `./credenitals` dir. When adding new
 credential, make sure the directory name is camel-cased. The directory should
 contain a logo image (with `.jpg` or `.png` file extensions) and the credential
-in the `credential.json` file.
+in the `credential.json` file. Additionally, you can also add a file for the
+credential context (for example see - `./credentials/movieTicket`) if you want
+to host the contexts in `https://playground.chapi.io/`.
 
 ### Get the path to credentials directory
 ```

--- a/credentials/alumni/context-v1.json
+++ b/credentials/alumni/context-v1.json
@@ -1,0 +1,13 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@protected": true,
+    "name": "https://schema.org/name",
+    "description": "https://schema.org/description",
+    "identifier": "https://schema.org/identifier",
+    "image": {
+      "@id": "https://schema.org/image",
+      "@type": "@id"
+    }
+  }
+}

--- a/credentials/alumni/credential.json
+++ b/credentials/alumni/credential.json
@@ -2,7 +2,7 @@
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
     "https://www.w3.org/2018/credentials/examples/v1",
-    "https://playground.chapi.io/examples/alumni/alumni-v1.json"
+    "https://playground.chapi.io/examples/alumni/context-v1.json"
   ],
   "type": ["VerifiableCredential", "AlumniCredential"],
   "issuer": {

--- a/credentials/movieTicket/context-v1.json
+++ b/credentials/movieTicket/context-v1.json
@@ -1,0 +1,37 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@protected": true,
+    "MovieTicketCredential": {
+      "@id": "https://playground.chapi.io/examples/movieTicket/vocab#MovieTicketCredential"
+    },
+    "Ticket": "https://schema.org/Ticket",
+    "owns": {
+      "@id": "https://schema.org/owns",
+      "@type": "@id"
+    },
+    "name": "https://schema.org/name",
+    "description": "https://schema.org/description",
+    "identifier": "https://schema.org/identifier",
+    "image": {
+      "@id": "https://schema.org/image",
+      "@type": "@id"
+    },
+    "location": {
+      "@id": "https://schema.org/location",
+      "@type": "@id"
+    },
+    "startDate": "https://schema.org/startDate",
+    "ticketNumber": "https://schema.org/ticketNumber",
+    "ticketedSeat": "https://schema.org/ticketedSeat",
+    "ticketToken": "https://schema.org/ticketToken",
+    "seatNumber": "https://schema.org/seatNumber",
+    "seatRow": "https://schema.org/seatRow",
+    "seatSection": "https://schema.org/seatSection",
+    "address": "https://schema.org/PostalAddress",
+    "addressLocality": "https://schema.org/addressLocality",
+    "addressRegion": "https://schema.org/addressRegion",
+    "postalCode": "https://schema.org/postalCode",
+    "streetAddress": "https://schema.org/streetAddress"
+  }
+}

--- a/credentials/movieTicket/credential.json
+++ b/credentials/movieTicket/credential.json
@@ -1,7 +1,7 @@
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://playground.chapi.io/examples/movieTicket/ticket-v1.json"
+    "https://playground.chapi.io/examples/movieTicket/context-v1.json"
   ],
   "type": [
     "VerifiableCredential",

--- a/credentials/safeChef/context-v1.json
+++ b/credentials/safeChef/context-v1.json
@@ -1,0 +1,38 @@
+{
+  "@context": {
+    "@protected": true,
+
+    "FoodSafetyCertificationCredential": {
+      "@id": "https://playground.chapi.io/examples/safeChef/vocab#FoodSafetyCertificationCredential"
+    },
+
+    "name": "https://schema.org/name",
+    "description": "https://schema.org/description",
+    "image": "https://schema.org/image",
+    "certification": {
+      "@id": "https://credential-handler.github.io/vc-examples/safechef#certification"
+    },
+
+    "FoodSafetyCertification": {
+      "@id": "https://credential-handler.github.io/vc-examples/safechef#FoodSafetyCertification",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+
+        "certificateId": {
+          "@id": "https://credential-handler.github.io/vc-examples/safechef#certificateId",
+          "@type": "xsd:string"
+        },
+        "examDate": {
+          "@id": "https://credential-handler.github.io/vc-examples/safechef#examDate",
+          "@type": "xsd:dateTime"
+        },
+        "testCode": {
+          "@id": "https://credential-handler.github.io/vc-examples/safechef#testCode",
+          "@type": "xsd:string"
+        }
+      }
+    }
+  }
+}

--- a/credentials/safeChef/credential.json
+++ b/credentials/safeChef/credential.json
@@ -1,7 +1,7 @@
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://testing-json-ld.pages.dev/safechef-v1.context.jsonld"
+    "https://playground.chapi.io/examples/safeChef/context-v1.json"
   ],
   "type": [
     "VerifiableCredential",


### PR DESCRIPTION
This has been tested on Chapi Playground. 

NOTE: For testing though I had to point the host of context urls to Chapi Playground `localhost` and then npm link the changes and was able to issue the credentials and verify them. 