### PR TITLE
Remove expiration date from retail coupon vc.

### DIFF
--- a/credentials/retail-coupon/credential.json
+++ b/credentials/retail-coupon/credential.json
@@ -12,7 +12,6 @@
   },
   "name": "Digital coupon: 50% off on disco balls, small or large",
   "issuanceDate": "2023-06-04T00:00:00Z",
-  "expirationDate": "2023-08-01T08:00:00Z",
   "image": "https://playground.chapi.io/examples/retail-coupon/image.png",
   "credentialSubject": {
     "id": "did:key:123",


### PR DESCRIPTION
#### _Resolves Retail Coupon does not work in vc-playground because it has expired_

---

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

- Remove expirationDate property from the credential.json of the retail coupon.

<br/>

### What is the current behavior? (You can also link to an open issue here)

- When retail coupon is issued it errors out in the vc-playground because it has expired.

<br/>

### What is the new behavior?

- Retail coupon VC can now be used in the vc-playground.

<br/>

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

- [ ] Yes
- [X] No

<br/>

### How has this been tested?

1. Updating the credential.json by removing the expiration date
2. Saving the credential.json to a private GitHub Gist
3. Using the raw Gist url to test the issuing of the credential in locally running vc-playground

<br/>

### Screenshots:

> Current result from issuing retail coupon vc
> <img alt="expired_credential" src="https://github.com/credential-handler/vc-examples/assets/56396286/d9b0f9fd-cdd3-4387-851b-953388de0b52" />

> Result from issuing retail coupon sans expiration date
> <img alt="credential_sans_expiration_date" src="https://github.com/credential-handler/vc-examples/assets/56396286/212f1cd5-41b7-4b73-84ec-f4c78be0e9c0" />
