### PR TITLE
Ignore package-lock.json.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 TAGS
 dist
 node_modules
+package-lock.json


### PR DESCRIPTION
If we do not want it committed, we should ignore it.