### PR TITLE
Update jff3 credential

### DIFF
--- a/credentials/jff3/credential.json
+++ b/credentials/jff3/credential.json
@@ -11,15 +11,18 @@
   "name": "JFF x vc-edu PlugFest 3 Interoperability",
   "issuer": {
     "type": ["Profile"],
-    "id": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
+    "id": "did:key:z6MknTHVAhsRyNzBG6h5wjTrg76UGUaBoXS5Vs9Apfr1fbCj",
     "name": "Jobs for the Future (JFF)",
     "url": "https://www.jff.org/",
-    "image": "https://w3c-ccg.github.io/vc-ed/plugfest-1-2022/images/JFF_LogoLockup.png"
+    "image": {
+      "id": "https://w3c-ccg.github.io/vc-ed/plugfest-1-2022/images/JFF_LogoLockup.png",
+      "type": ["Image"]
+    }
   },
-  "issuanceDate": "2023-07-20T07:05:44Z",
+  "issuanceDate": "2023-10-09T00:00:00Z",
   "credentialSubject": {
     "type": ["AchievementSubject"],
-    "id": "did:key:123",
+    "id": "did:example:123",
     "achievement": {
       "id": "urn:uuid:ac254bd5-8fad-4bb1-9d29-efd938536926",
       "type": ["Achievement"],
@@ -27,7 +30,7 @@
       "description": "This wallet supports the use of W3C Verifiable Credentials and has demonstrated interoperability during the presentation request workflow during JFF x VC-EDU PlugFest 3.",
       "criteria": {
         "type": "Criteria",
-        "narrative": "Wallet solutions providers earned this badge by demonstrating interoperability during the presentation request workflow. This includes successfully receiving a presentation request, allowing the holder to select at least two types of verifiable credentials to create a verifiable presentation, returning the presentation to the requestor, and passing verification of the presentation and the included credentials."
+        "narrative": "Wallet solution providers earned this badge by demonstrating interoperability during the presentation request workflow. This included successfully receiving a presentation request, allowing the holder to select at least two types of verifiable credentials to create a verifiable presentation, returning the presentation to the requester, and passing verification of the presentation and the included credentials."
       },
       "image": {
         "id":"https://w3c-ccg.github.io/vc-ed/plugfest-3-2023/images/JFF-VC-EDU-PLUGFEST3-badge-image.png",


### PR DESCRIPTION
Open badge issuer (Profile) image property is supposed to be an object with type "Image".

Issuer ID and criteria are from https://github.com/w3c-ccg/vc-ed/pull/49

Use [demo day](https://w3c-ccg.github.io/vc-ed/plugfest-3-2023/demos) (past) as issuance date.

Use did:example rather than invalid did:key.