### PR TITLE
Add selective disclosure query to for drivers license credential

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # vc-examples Changelog
 
+## 6.7.0 - 2024-08-xx
+
+### Added
+- Include selective disclosure query for DL.
+
 ## 6.6.1 - 2024-07-19
 
 ### Fixed

--- a/credentials/utopia-dl/queries.json
+++ b/credentials/utopia-dl/queries.json
@@ -20,5 +20,34 @@
         "ecdsa-sd-2023"
       ]
     }
+  },
+  "Driver's License (Name & Number Only)": {
+    "type": "QueryByExample",
+    "credentialQuery": {
+      "reason": "Please present your ISO 18013 Drivers License Verifiable Credential(s) to complete the verification process.",
+      "example": {
+        "@context": [
+          "https://www.w3.org/2018/credentials/v1",
+          "https://www.w3.org/ns/credentials/examples/v2",
+          "https://w3id.org/vdl/v1",
+          "https://w3id.org/vdl/aamva/v1"
+        ],
+        "type": ["Iso18013DriversLicenseCredential"],
+        "credentialSubject": {
+          "driversLicense": {
+            "document_number": "",
+            "given_name": "",
+            "family_name": ""
+          }
+        }
+      },
+      "acceptedCryptosuites": [
+        "Ed25519Signature2020",
+        "eddsa-rdfc-2022",
+        "ecdsa-rdfc-2019",
+        "bbs-2023",
+        "ecdsa-sd-2023"
+      ]
+    }
   }
 }

--- a/credentials/utopia-dl/queries.json
+++ b/credentials/utopia-dl/queries.json
@@ -28,7 +28,6 @@
       "example": {
         "@context": [
           "https://www.w3.org/2018/credentials/v1",
-          "https://www.w3.org/ns/credentials/examples/v2",
           "https://w3id.org/vdl/v1"
         ],
         "type": ["Iso18013DriversLicenseCredential"],

--- a/credentials/utopia-dl/queries.json
+++ b/credentials/utopia-dl/queries.json
@@ -29,8 +29,7 @@
         "@context": [
           "https://www.w3.org/2018/credentials/v1",
           "https://www.w3.org/ns/credentials/examples/v2",
-          "https://w3id.org/vdl/v1",
-          "https://w3id.org/vdl/aamva/v1"
+          "https://w3id.org/vdl/v1"
         ],
         "type": ["Iso18013DriversLicenseCredential"],
         "credentialSubject": {


### PR DESCRIPTION
#### _Resolves #58_

---

### What kind of change does this PR introduce?

- Configuration update.

<br/>

### What is the current behavior?

- No current example of selective disclosure with a driver's license credential.

<br/>

### What is the new behavior?

- Include selective disclosure example for driver's license that requests subject's name & DL#.

<br/>

### Does this PR introduce a breaking change?

- No

<br/>

### How has this been tested?

- Locally tested by issuing and verifying DL credential.

<br/>

### Screenshots: n/a