### PR TITLE
Remove `proof` from JFF and PRC.

### DIFF
--- a/credentials/jff/credential.json
+++ b/credentials/jff/credential.json
@@ -28,12 +28,5 @@
       },
       "image": "https://w3c-ccg.github.io/vc-ed/plugfest-1-2022/images/plugfest-1-badge-image.png"
     }
-  },
-  "proof": {
-    "type": "Ed25519Signature2018",
-    "created": "2022-05-31T21:09:29Z",
-    "verificationMethod": "did:key:z6MkrHKzgsahxBLyNAbLQyB1pcWNYC9GmywiWPgkrvntAZcj#z6MkrHKzgsahxBLyNAbLQyB1pcWNYC9GmywiWPgkrvntAZcj",
-    "proofPurpose": "assertionMethod",
-    "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..Q05Nb7ufRWi8b8MO11einZZzRgwU9iauqiKoB-tKCGRUIGWTM_-HUQMXsSE9rYm3wuv45qa5gl4TIl5lwWgvDA"
   }
 }

--- a/credentials/prc/credential.json
+++ b/credentials/prc/credential.json
@@ -33,12 +33,5 @@
     "commuterClassification": "C1",
     "birthCountry": "Arcadia",
     "birthDate": "1978-07-17"
-  },
-  "proof": {
-    "type": "Ed25519Signature2020",
-    "created": "2021-11-23T19:19:23Z",
-    "verificationMethod": "did:example:ebfeb1f712ebc6f1c276e12ec21#keys-1",
-    "proofPurpose": "assertionMethod",
-    "proofValue": "z58Di5AdefOkpMnoe1Fggr9ArgSadskklq1dAkKQfFDqqwkpQWfkherwSDF12FFaaekpalqkkg8DDasdkoplmnqKt"
   }
 }


### PR DESCRIPTION
Not sure why these are in the credentials. The VC Playground (and other
systems) will/should add them when turned from credentials into
Verifiable Credentials.
