### PR TITLE
Add npm run check script for safe mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,20 @@ To run test:
 npm test
 ```
 
+To check credentials against local (and remote) contexts:
+
+```sh
+npm run check
+```
+
+This uses [jsonld.js](https://github.com/digitalbazaar/jsonld.js)'s
+"[Safe Mode](https://github.com/digitalbazaar/jsonld.js?tab=readme-ov-file#safe-mode)"
+to to check for missing terms.
+
+All local example context files are added as static contexts mapped to their
+future publication URLs via
+[jsonld-document-loader](https://github.com/digitalbazaar/jsonld-document-loader).
+
 ## Usage
 
 ### Add / Update a Verifiable Credential

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "main": "./lib/index.js",
   "scripts": {
+    "check": "node test/safe-mode-check.js",
     "test": "npm run lint && npm run test-node",
     "test-node": "cross-env NODE_ENV=test mocha --preserve-symlinks -t 10000 test/*.spec.js",
     "lint": "eslint ."
@@ -15,12 +16,16 @@
     "lib/*.js"
   ],
   "devDependencies": {
+    "@11ty/eleventy-fetch": "^4.0.1",
     "chai": "^4.3.7",
     "cross-env": "^7.0.3",
     "eslint": "^8.34.0",
     "eslint-config-digitalbazaar": "^4.2.0",
     "eslint-plugin-jsdoc": "^40.0.0",
     "eslint-plugin-unicorn": "^45.0.2",
+    "glob": "^11.0.0",
+    "jsonld": "^8.3.2",
+    "jsonld-document-loader": "^2.2.0",
     "mocha": "^10.2.0"
   },
   "repository": {

--- a/test/safe-mode-check.js
+++ b/test/safe-mode-check.js
@@ -1,0 +1,49 @@
+import {contextsDir, credentialsDir} from '../lib/index.js';
+import EleventyFetch from '@11ty/eleventy-fetch';
+import fs from 'node:fs';
+import {glob} from 'glob';
+import jsonld from 'jsonld';
+import {JsonLdDocumentLoader} from 'jsonld-document-loader';
+
+const jdl = new JsonLdDocumentLoader();
+
+// Loop all local context files and add them as static contexts at the base URL
+const baseUrl = 'https://contexts.vcplayground.org/examples/';
+const paths = await glob([`${contextsDir}/**/*.json`],
+  {stat: true, withFileTypes: true});
+const timeSortedFiles = paths
+  .sort((a, b) => a.mtimeMs - b.mtimeMs)
+  .map(path => path.fullpath());
+
+const latestLocalContexts = new Map(timeSortedFiles.map(path => {
+  const parts = path.split('/');
+  return [parts[parts.length - 2], parts[parts.length - 1]];
+}));
+
+latestLocalContexts.forEach((file, dir) => {
+  const context = JSON.parse(
+    fs.readFileSync(`${contextsDir}/${dir}/${file}`));
+  const url = `${baseUrl}${dir}/${file}`;
+  jdl.addStatic(url, context);
+});
+jdl.setProtocolHandler({protocol: 'https',
+  handler: {
+    async get({url}) {
+      return EleventyFetch(url, {duration: '1d', type: 'json'});
+    }
+  }});
+const loader = jdl.build();
+jsonld.documentLoader = loader;
+
+const credentialPaths = await glob([`${credentialsDir}/**/credential.json`]);
+credentialPaths.forEach(async credentialPath => {
+  const credential = JSON.parse(await fs.readFileSync(credentialPath));
+  try {
+    await jsonld.expand(credential, {safe: true});
+    console.log('👍 All terms correctly defined in',
+      credentialPath);
+  } catch(err) {
+    console.log('😢 Errors found in', credentialPath);
+    console.dir(err, {depth: 5});
+  }
+});


### PR DESCRIPTION
Uses `jsonld.expand()` safe mode to find undefined terms.

It uses the `jsonld-document-loader` to map locally defined contexts
to their future publication URLs allowing local testing of in progress
context changes without the need to first publish the context or use
temporary URLs for the contexts and avoids the temptation to use
inline contexts.
