### PR TITLE
Add publish script for static assets.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ TAGS
 dist
 node_modules
 package-lock.json
+_site/

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "./lib/index.js",
   "scripts": {
     "check": "node test/safe-mode-check.js",
+    "publish": "mkdir _site/ && cp -r contexts/ _site/ && cp -r credentials/ _site/",
     "test": "npm run lint && npm run test-node",
     "test-node": "cross-env NODE_ENV=test mocha --preserve-symlinks -t 10000 test/*.spec.js",
     "lint": "eslint ."


### PR DESCRIPTION
This would greatly streamline releasing the examples for use on the VC Playground.

Plan is to mint a new URL for _example_ contexts and credentials:
`https://examples.vcplayground.org/contexts/` and `https://examples.vcplaygound.og/credentials/`