### PR TITLE
Bring controller term into local context.

### DIFF
--- a/contexts/utopia-natcert/v2.json
+++ b/contexts/utopia-natcert/v2.json
@@ -16,6 +16,6 @@
         }
       }
     },
-    "DidAuthnConfidenceMethod": "https://examples.vcplayground.org/contexts/utopia-natcert/vocab#DidAuthnConfidenceMethod"
+    "DidAuthnConfidenceMethod": "https://examples.vcplayground.org/vocabs/utopia-natcert#DidAuthnConfidenceMethod"
   }
 }

--- a/contexts/utopia-natcert/v2.json
+++ b/contexts/utopia-natcert/v2.json
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@protected": true,
+    "confidenceMethod": {
+      "@id": "https://www.w3.org/2018/credentials#confidenceMethod",
+      "@type": "@id"
+    },
+
+    "ConfidenceMethod": {
+      "@protected": true,
+      "@id": "https://www.w3.org/2018/credentials#ConfidenceMethod",
+      "@context": {
+        "controller": {
+          "@id": "https://w3id.org/security#controller",
+          "@type": "@id"
+        }
+      }
+    },
+    "DidAuthnConfidenceMethod": "https://examples.vcplayground.org/contexts/utopia-natcert/vocab#DidAuthnConfidenceMethod"
+  }
+}

--- a/credentials/utopia-natcert/credential.json
+++ b/credentials/utopia-natcert/credential.json
@@ -5,8 +5,7 @@
     "https://w3id.org/security/data-integrity/v2",
     "https://examples.vcplayground.org/contexts/shim-VCv1.1-common-example-terms/v1.json",
     "https://w3id.org/vc/render-method/v2rc1",
-    "https://examples.vcplayground.org/contexts/utopia-natcert/v1.json",
-    "https://www.w3.org/ns/controller/v1"
+    "https://examples.vcplayground.org/contexts/utopia-natcert/v2.json"
   ],
   "type": [
     "VerifiableCredential",


### PR DESCRIPTION
The `controller` term is now defined in a newly renamed specification.
Consequently, it was early to depend on that earlier context, and so
the use of the term is now defined in the NatCert for v1.1 v2 context.
