### PR TITLE
Add redirects for contexts from their Naming Things with Hashes URLs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,25 @@ used in the creation of these URLs, but the above absolute path would be
 consistent across domain names which implemented RFC6920 + JCS for their context
 URLs.
 
+### `Repr-Digest`
+
+In addition to the above URLs,
+[`Repr-Digest`](https://datatracker.ietf.org/doc/html/rfc9530#name-the-repr-digest-field)
+fields are provided in the responses to the human-friendly named URLs, such that
+the hash can be compared with cashes, stored copies, etc. For example:
+
+```http
+HEAD /contexts/utopia-natcert/v2.json HTTP/1.1
+Host: examples.vcplayground.org
+```
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/ld+json
+Repr-Digest: sha-256=deb95693d486afdb1909289e399d398a4c8bceeea12f405c32359ea81c98b48a
+Link: </.well-known/ni/sha-256/deb95693d486afdb1909289e399d398a4c8bceeea12f405c32359ea81c98b48a>; rel="alternate"; type="application/ld+json"
+```
+
 ## Contribute
 
 See [the contribute file](https://github.com/digitalbazaar/bedrock/blob/master/CONTRIBUTING.md)!

--- a/README.md
+++ b/README.md
@@ -118,6 +118,23 @@ following command:
 $ npm -s run extract
 ```
 
+## Hash-based URLs for contexts
+
+This is an experimental feature. We have provided redirects using identifiers
+created from the SHA-256 hashed canonicalized JSON (JCS) of the JSON-LD contexts
+in this repository at their
+[Naming things with Hashes (RFC6920)](https://www.rfc-editor.org/rfc/rfc6920.html)
+`.well-known` URLs. For example:
+
+```
+/.well-known/ni/sha-256/deb95693d486afdb1909289e399d398a4c8bceeea12f405c32359ea81c98b48a /contexts/utopia-natcert/v2.json
+```
+
+Sadly, RFC6920 does not currently support a method for expressing that JCS was
+used in the creation of these URLs, but the above absolute path would be
+consistent across domain names which implemented RFC6920 + JCS for their context
+URLs.
+
 ## Contribute
 
 See [the contribute file](https://github.com/digitalbazaar/bedrock/blob/master/CONTRIBUTING.md)!

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "check": "node test/safe-mode-check.js",
     "extract": "node test/safe-mode-check.js extract",
     "publish": "eleventy",
+    "serve": "wrangler pages dev _site/ --compatibility-date=2025-04-02",
     "test": "npm run lint && npm run test-node",
     "test-node": "cross-env NODE_ENV=test mocha --preserve-symlinks -t 10000 test/*.spec.js",
     "lint": "eslint ."
@@ -48,6 +49,8 @@
   },
   "homepage": "https://github.com/credential-handler/vc-examples#readme",
   "dependencies": {
-    "@11ty/eleventy": "^3.1.2"
+    "@11ty/eleventy": "^3.1.2",
+    "canonify": "^2.1.1",
+    "wrangler": "^4.31.0"
   }
 }

--- a/src/_data/contexts.js
+++ b/src/_data/contexts.js
@@ -1,0 +1,31 @@
+/**!
+ * Copyright 2025 Digital Bazaar, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {canonify} from 'canonify';
+import crypto from 'node:crypto';
+import {fileURLToPath} from 'node:url';
+import fs from 'node:fs';
+import {glob} from 'glob';
+import path from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const contextsDir = path.resolve(__dirname, '../../contexts');
+const files = glob.sync('**/*.json', {cwd: contextsDir, nodir: true});
+
+const contexts = [];
+
+for(const file of files) {
+  const filePath = path.join(contextsDir, file);
+  const json = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  const canonized = canonify(json);
+  const hash = crypto.createHash('sha256').update(canonized).digest('hex');
+  const relativePath = path.relative(__dirname, filePath);
+  contexts.push({hash, path: relativePath.slice(5)});
+}
+
+export default contexts;

--- a/src/_headers.liquid
+++ b/src/_headers.liquid
@@ -1,0 +1,10 @@
+---
+permalink: _headers
+---
+
+{%- for context in contexts %}
+{{ context.path }}
+  Repr-Digest: sha-256={{ context.hash }}
+  Content-Type: application/ld+json
+  Link: </.well-known/ni/sha-256/{{ context.hash }}>; rel="alternate"; type="application/ld+json"
+{%-  endfor -%}

--- a/src/_redirects.liquid
+++ b/src/_redirects.liquid
@@ -1,0 +1,6 @@
+---
+permalink: _redirects
+---
+{%- for context in contexts -%}
+/.well-known/ni/sha-256/{{context.hash}} {{context.path}}
+{% endfor -%}


### PR DESCRIPTION
This is some experimentation around hash values for naming contexts so the hash name can be used for dereferencing or cross-referencing if/as needed.

Past hash values are not kept...but potentially could be by wiring in a key-value store and appending it each time we publish the site (and protecting past-hashes to prevent loss). Happy to explore that if we're curious about that approach.