### PR TITLE
Remove unused context from retail-dw credential examples.

### DIFF
--- a/credentials/coupon/credential.json
+++ b/credentials/coupon/credential.json
@@ -2,7 +2,6 @@
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
     "https://w3id.org/retail-dw/v1rc1",
-    "https://examples.vcplayground.org/contexts/shim-render-method-term/v1.json",
     "https://w3id.org/vc/render-method/v2rc1"
   ],
   "type": [

--- a/credentials/loyalty-card/credential.json
+++ b/credentials/loyalty-card/credential.json
@@ -2,7 +2,6 @@
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
     "https://w3id.org/retail-dw/v1rc1",
-    "https://examples.vcplayground.org/contexts/shim-render-method-term/v1.json",
     "https://w3id.org/vc/render-method/v2rc1"
   ],
   "type": [

--- a/credentials/payment-token/credential.json
+++ b/credentials/payment-token/credential.json
@@ -2,7 +2,6 @@
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
     "https://w3id.org/retail-dw/v1rc1",
-    "https://examples.vcplayground.org/contexts/shim-render-method-term/v1.json",
     "https://w3id.org/vc/render-method/v2rc1"
   ],
   "type": [


### PR DESCRIPTION
- Deletes the shim-render-method-term context line from coupon, loyalty card, and payment token credential files.
- Ensures credentials use only relevant context definitions.