### PR TITLE
Add missing `id` values.

### DIFF
--- a/credentials/fema-ics-100/credential.json
+++ b/credentials/fema-ics-100/credential.json
@@ -8,6 +8,7 @@
     "VerifiableCredential",
     "OpenBadgeCredential"
   ],
+  "id": "urn:uuid:e9d23c16-0668-4166-a9cc-45102ed7ea4d",
   "name": "FEMA IS-100.C: ICS Foundation Certified",
   "issuer": {
     "type": ["Profile"],
@@ -17,6 +18,7 @@
   "validFrom": "2024-01-01T00:00:00Z",
   "validUntil": "2026-02-01T00:00:00Z",
   "credentialSubject": {
+    "id": "urn:uuid:849ce513-f6d9-49b0-b118-91371187eec2",
     "type": ["AchievementSubject"],
     "achievement": {
       "id": "urn:uuid:ac254bd5-8fad-4bb1-9d29-dfe049647037",


### PR DESCRIPTION
The `id` property is required by OpenBadges 3.x:
https://www.imsglobal.org/spec/ob/v3p0

Validated via https://verifybadge.org/