### PR TITLE
feat: add utopia-agency-employee-badge IdentificationDocument credential

### DIFF
--- a/credentials/utopia-agency-employee-badge/credential.json
+++ b/credentials/utopia-agency-employee-badge/credential.json
@@ -1,0 +1,26 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://w3id.org/identification/v1rc1",
+    {
+      "agency": "https://schema.org/memberOf"
+    }
+  ],
+  "id": "urn:uuid:b3d7c2e1-4f5a-6b7c-8d9e-0a1b2c3d4e5f",
+  "type": ["VerifiableCredential", "IdentificationDocumentCredential"],
+  "name": "Utopia Agency Employee Badge",
+  "issuer": {
+    "id": "https://www.utopia-dmv.example",
+    "type": ["Profile"],
+    "name": "Utopia Department of Motor Vehicles"
+  },
+  "validFrom": "2026-01-15T00:00:00Z",
+  "validUntil": "2028-01-14T23:59:59Z",
+  "credentialSubject": {
+    "id": "urn:uuid:d4e5f6a7-b8c9-0d1e-2f3a-4b5c6d7e8f9a",
+    "type": "Person",
+    "givenName": "Jordan",
+    "familyName": "Casey",
+    "agency": "Utopia Highway Patrol"
+  }
+}

--- a/credentials/utopia-agency-employee-badge/credential.json
+++ b/credentials/utopia-agency-employee-badge/credential.json
@@ -1,25 +1,23 @@
 {
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
-    "https://w3id.org/identification/v1rc1",
-    {
-      "agency": "https://schema.org/memberOf"
-    }
+    "https://w3id.org/identification/v1rc1"
   ],
-  "id": "urn:uuid:b3d7c2e1-4f5a-6b7c-8d9e-0a1b2c3d4e5f",
   "type": ["VerifiableCredential", "IdentificationDocumentCredential"],
   "name": "Utopia Agency Employee Badge",
   "issuer": {
-    "id": "https://www.utopia-records.example",
-    "name": "Utopia Central Records Office"
+    "id": "https://employment.utopia.example",
+    "name": "Utopia Employment Agency"
   },
   "validFrom": "2026-01-15T00:00:00Z",
   "validUntil": "2028-01-14T23:59:59Z",
   "credentialSubject": {
-    "id": "urn:uuid:d4e5f6a7-b8c9-0d1e-2f3a-4b5c6d7e8f9a",
     "type": "Person",
     "givenName": "Jordan",
     "familyName": "Casey",
-    "agency": "Utopia Department of Parks and Recreation"
+    "worksFor": {
+      "id": "https://parks.utopia.example/",
+      "name": "Utopia Department of Parks and Recreation"
+    }
   }
 }

--- a/credentials/utopia-agency-employee-badge/credential.json
+++ b/credentials/utopia-agency-employee-badge/credential.json
@@ -10,9 +10,8 @@
   "type": ["VerifiableCredential", "IdentificationDocumentCredential"],
   "name": "Utopia Agency Employee Badge",
   "issuer": {
-    "id": "https://www.utopia-dmv.example",
-    "type": ["Profile"],
-    "name": "Utopia Department of Motor Vehicles"
+    "id": "https://www.utopia-records.example",
+    "name": "Utopia Central Records Office"
   },
   "validFrom": "2026-01-15T00:00:00Z",
   "validUntil": "2028-01-14T23:59:59Z",
@@ -21,6 +20,6 @@
     "type": "Person",
     "givenName": "Jordan",
     "familyName": "Casey",
-    "agency": "Utopia Highway Patrol"
+    "agency": "Utopia Department of Parks and Recreation"
   }
 }

--- a/credentials/utopia-agency-employee-badge/queries.json
+++ b/credentials/utopia-agency-employee-badge/queries.json
@@ -1,19 +1,31 @@
 {
-  "web": {
-    "VerifiablePresentation": {
-      "query": [{
-        "type": "QueryByExample",
-        "credentialQuery": [{
-          "reason": "An Agency Employee Badge is required.",
-          "example": {
-            "@context": [
-              "https://www.w3.org/ns/credentials/v2",
-              "https://w3id.org/identification/v1rc1"
-            ],
-            "type": "IdentificationDocumentCredential"
+  "default": {
+    "type": "QueryByExample",
+    "credentialQuery": [
+      {
+        "reason": "Please present your IdentificationDocumentCredential Verifiable Credential(s) to complete the verification process.",
+        "example": {
+          "@context": [
+            "https://www.w3.org/ns/credentials/v2",
+            "https://w3id.org/identification/v1rc1"
+          ],
+          "type": [
+            "IdentificationDocumentCredential"
+          ],
+          "credentialSubject": {
+            "worksFor": {
+              "id": "https://parks.utopia.example/"
+            }
           }
-        }]
-      }]
-    }
+        },
+        "acceptedCryptosuites": [
+          "Ed25519Signature2020",
+          "eddsa-rdfc-2022",
+          "ecdsa-rdfc-2019",
+          "bbs-2023",
+          "ecdsa-sd-2023"
+        ]
+      }
+    ]
   }
 }

--- a/credentials/utopia-agency-employee-badge/queries.json
+++ b/credentials/utopia-agency-employee-badge/queries.json
@@ -1,0 +1,19 @@
+{
+  "web": {
+    "VerifiablePresentation": {
+      "query": [{
+        "type": "QueryByExample",
+        "credentialQuery": [{
+          "reason": "An Agency Employee Badge is required.",
+          "example": {
+            "@context": [
+              "https://www.w3.org/ns/credentials/v2",
+              "https://w3id.org/identification/v1rc1"
+            ],
+            "type": "IdentificationDocumentCredential"
+          }
+        }]
+      }]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a Utopia Agency Employee Badge credential — a generic example of an identification document issued to a government agency's own employee.

- **Type**: `IdentificationDocumentCredential` from the [Identification Document vocabulary](https://w3id.org/identification/v1rc1)
- **Fields**: `givenName` + `familyName` (vocab `Person` type), plus `agency` as an inline `schema.org/memberOf` term
- **Issuer**: Utopia Central Records Office (a central authority issuing badges on behalf of named agencies)
- **Subject**: Jordan Casey, Utopia Department of Parks and Recreation — deliberately a mundane, arbitrary department to keep the example generic rather than modeled on any specific real-world agency

## Open questions for reviewers

1. Is `schema.org/memberOf` the right mapping for `agency`, or should we use `schema.org/worksFor` with an `Organization` object?
2. Should we add a `renderMethod` now or defer to a follow-up?

## Test plan

- [ ] Issue this credential from vc-playground
- [ ] Verify it renders in Veres Wallet via the generic `IdentificationDocumentCredential` card design
- [x] `node test/safe-mode-check.js` passes (previously failed on `issuer.type: ["Profile"]`, now removed — identification-vocab doesn't define `Profile` as a term, and VCDM 2.0 doesn't require `issuer.type`)