### PR TITLE
feat: add utopia-vehicle-insurance VehicleInsuranceCredential example

### DIFF
--- a/credentials/utopia-vehicle-insurance/credential.json
+++ b/credentials/utopia-vehicle-insurance/credential.json
@@ -1,0 +1,44 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://w3id.org/vvc/v1rc2"
+  ],
+  "type": ["VerifiableCredential", "VehicleInsuranceCredential"],
+  "name": "Utopia Vehicle Insurance Certificate",
+  "issuer": {
+    "id": "https://dmv.utopia.example",
+    "name": "Utopia Department of Motor Vehicles"
+  },
+  "validFrom": "2026-01-15T00:00:00Z",
+  "validUntil": "2028-01-14T23:59:59Z",
+  "credentialSubject": {
+    "type": "VehicleInsuranceInformation",
+    "vehicleIdentificationNumber": "4Y1SL65848Z411439",
+    "manufacturer": {
+      "type": "Organization",
+      "name": "Honda"
+    },
+    "owner": [
+      {
+        "type": "Person",
+        "name": "Jordan Casey",
+        "address": {
+          "type": "PostalAddress",
+          "streetAddress": "123 LEMON AVE",
+          "addressLocality": "UTOPOLIS",
+          "addressRegion": "UTOPIA",
+          "postalCode": "12345"
+        }
+      }
+    ],
+    "policyNumber": "CI12345000",
+    "policyStartDate": "2025-01-01",
+    "policyEndDate": "2026-01-01",
+    "coverageAmount": {
+      "type": "MonetaryAmount",
+      "currency": "USD",
+      "value": "1000000"
+    },
+    "licensePlateIdentifier": "ABC1234"
+  }
+}

--- a/credentials/utopia-vehicle-insurance/queries.json
+++ b/credentials/utopia-vehicle-insurance/queries.json
@@ -1,0 +1,26 @@
+{
+  "default": {
+    "type": "QueryByExample",
+    "credentialQuery": [
+      {
+        "reason": "Please present your VehicleInsuranceCredential Verifiable Credential(s) to complete the verification process.",
+        "example": {
+          "@context": [
+            "https://www.w3.org/ns/credentials/v2",
+            "https://w3id.org/vvc/v1rc2"
+          ],
+          "type": [
+            "VehicleInsuranceCredential"
+          ]
+        },
+        "acceptedCryptosuites": [
+          "Ed25519Signature2020",
+          "eddsa-rdfc-2022",
+          "ecdsa-rdfc-2019",
+          "bbs-2023",
+          "ecdsa-sd-2023"
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Adds a Utopia Vehicle Insurance Certificate credential — a generic example of a vehicle insurance record issued by a government motor vehicle agency.

- **Type**: `VehicleInsuranceCredential` from the [Vehicle Credentials Vocabulary](https://w3id.org/vvc/v1rc2)
- **Fields**: `vehicleIdentificationNumber`, `manufacturer` (Organization), `owner` (Person[] with PostalAddress), `policyNumber`, `policyStartDate`/`policyEndDate`, `coverageAmount` (MonetaryAmount), `licensePlateIdentifier`
- **Issuer**: Utopia Department of Motor Vehicles
- **Subject**: Jordan Casey, matching the person used across the other Utopia examples (employee badge, etc.)

## Open questions for reviewers

1. The vocabulary's own [published example](https://stateofca.github.io/vehicle-credentials-vocabulary/#vehicle-insurance-example) includes a `credentialSubject.validFrom` field, but `v1rc2`'s `VehicleInsuranceInformation` type-scoped context doesn't actually define `validFrom` — VCDM v2 only scopes that term to `VerifiableCredential`, not arbitrary nested subjects, so it fails safe-mode JSON-LD validation as published. Dropped it here; flagging in case the vocabulary itself needs a fix upstream (not DB-maintained, so we can't fix it directly).
2. No `image`/`renderMethod` yet, following the same deferred pattern as #144 — add a card design/render method now or in a follow-up?

## Test plan

- [x] `npm run check` passes (verified locally)
- [ ] Issue this credential from vc-playground
- [ ] Verify it renders in Veres Wallet